### PR TITLE
Improved errors sending the code and error from Google to device emiter

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -14,6 +14,7 @@ import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.auth.api.signin.GoogleSignInResult;
+import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.common.api.GoogleApiClient;
@@ -135,7 +136,11 @@ public class RNGoogleSigninModule
             _context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                     .emit("googleSignIn", params);
         } else {
-            params.putString("error", "signin error");
+            int code = result.getStatus().getStatusCode();
+            String error = GoogleSignInStatusCodes.getStatusCodeString(code);
+
+            params.putInt("code", code);
+            params.putString("error", error);
 
             _context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                     .emit("googleSignInError", params);


### PR DESCRIPTION
Instead of sending a json like 
```javascript
{
  "error": "signin error"
}
```

It sends a json with:

```javascript
{
  code: Number, // ie. 12501
  error: String // ie. "SIGN_IN_CANCELLED"
}
```

In that way we can handle better the errors from react-native.