### PR TITLE
added clientID to get Google Token and better error handler

### DIFF
--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -157,6 +157,7 @@ public class RNGoogleSigninModule
 
         if (result.isSuccess()) {
             GoogleSignInAccount acct = result.getSignInAccount();
+            params.putString("id", acct.getId());
             params.putString("name", acct.getDisplayName());
             params.putString("email", acct.getEmail());
             params.putString("accessToken", acct.getIdToken());


### PR DESCRIPTION
I have added support to retrieve the `TokenId` from a server `ClientId`, passed from `init()` method, in the same way iOS version works (also to send android Scopes)

```javascript
GoogleSignin.init(
  "google client id",
  ["email", "profile"]
);
```

I think it fixes apptailor/react-native-google-signin#2 also, since the token is always retrieved on the `googleSignIn` event.

---------

Also I have attached the other [PR#14](https://github.com/apptailor/react-native-google-signin/pull/14) in favor of this where I added the better error handling too, I leave the other too if you want to only add that one.

Instead of sending a json like 
```javascript
{
  "error": "signin error"
}
```

It sends a json with:

```javascript
{
  code: Number, // ie. 12501
  error: String // ie. "SIGN_IN_CANCELLED"
}
```

In that way we can handle better the errors from react-native.