### PR TITLE
Return idToken and serverAuthCode separately.

### DIFF
--- a/RNGoogleSignin/RNGoogleSignin.m
+++ b/RNGoogleSignin/RNGoogleSignin.m
@@ -59,7 +59,7 @@ RCT_EXPORT_METHOD(signOut)
                            @"name": user.profile.name,
                            @"email": user.profile.email,
                            @"idToken": user.authentication.idToken,
-                           @"serverAuthCode": user.serverAuthCode,
+                           @"serverAuthToken": user.serverAuthCode ? user.serverAuthCode : [NSNull null],
                            @"accessToken": user.authentication.accessToken,
                            @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow]
                            };

--- a/RNGoogleSignin/RNGoogleSignin.m
+++ b/RNGoogleSignin/RNGoogleSignin.m
@@ -7,15 +7,25 @@ RCT_EXPORT_MODULE();
 
 @synthesize bridge = _bridge;
 
-RCT_EXPORT_METHOD(configure:(NSString *)clientID withScopes:(NSArray *)scopes)
+RCT_EXPORT_METHOD(configure:(NSString *)clientID  withScopes:(NSArray *)scopes)
 {
-    [GIDSignIn sharedInstance].delegate = self;
-    [GIDSignIn sharedInstance].uiDelegate = self;
+  [self _configure:clientID serverClientID:nil withScopes:scopes];
+}
 
-    [GIDSignIn sharedInstance].clientID = clientID;
-    [GIDSignIn sharedInstance].scopes = scopes;
+RCT_EXPORT_METHOD(configureWithServerClientId:(NSString *)clientID  serverClientID:(NSString *)serverClientID withScopes:(NSArray *)scopes)
+{
+  [self _configure:clientID serverClientID:serverClientID withScopes:scopes];
+}
 
-    [[GIDSignIn sharedInstance] signInSilently];
+- (void) _configure:(NSString *)clientID  serverClientID:(NSString *)serverClientID withScopes:(NSArray *)scopes {
+  [GIDSignIn sharedInstance].delegate = self;
+  [GIDSignIn sharedInstance].uiDelegate = self;
+  
+  [GIDSignIn sharedInstance].clientID = clientID;
+  [GIDSignIn sharedInstance].serverClientID = serverClientID;
+  [GIDSignIn sharedInstance].scopes = scopes;
+  
+  [[GIDSignIn sharedInstance] signInSilently];
 }
 
 RCT_EXPORT_METHOD(signIn)
@@ -49,6 +59,7 @@ RCT_EXPORT_METHOD(signOut)
                            @"name": user.profile.name,
                            @"email": user.profile.email,
                            @"idToken": user.authentication.idToken,
+                           @"serverAuthCode": user.serverAuthCode,
                            @"accessToken": user.authentication.accessToken,
                            @"accessTokenExpirationDate": [NSNumber numberWithDouble:user.authentication.accessTokenExpirationDate.timeIntervalSinceNow]
                            };

--- a/RNGoogleSignin/RNGoogleSignin.m
+++ b/RNGoogleSignin/RNGoogleSignin.m
@@ -37,8 +37,12 @@ RCT_EXPORT_METHOD(signOut)
 - (void)signIn:(GIDSignIn *)signIn didSignInForUser:(GIDGoogleUser *)user withError:(NSError *)error {
 
     if (error != Nil) {
+        NSDictionary *body = @{
+                               @"message": error.description,
+                               @"code": [NSNumber numberWithInteger: error.code]
+                               };
         return [self.bridge.eventDispatcher sendAppEventWithName:@"googleSignInError"
-                                                            body:@{@"error": error.description}];
+                                                            body:body];
     }
 
     NSDictionary *body = @{

--- a/android-guide.md
+++ b/android-guide.md
@@ -80,8 +80,15 @@ var GoogleSignin = require('react-native-google-signin');
 var { DeviceEventEmitter } = require('react-native');
 
 GoogleSignin.configure(
-  clientID, // your client ID
+  clientID, // your client ID (Android type)
   [], // additional scopes (email is the default)
+); // somewhere in a componentDidMount.
+
+// Or if you want to get serverAuthToken
+GoogleSignin.configureWithServerClientId(
+  CLIENT_ID, // your client ID (Android type)
+  SERVER_CLIENT_ID, // client ID from your backend server (Web type)
+  [], // additional scopes (email is the default) calendar
 ); // somewhere in a componentDidMount.
 
 // Callback on sign-in errors

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -82,6 +82,7 @@ public class RNGoogleSigninModule
       if (clientID != null && !clientID.isEmpty()) {
         return new GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
           .requestIdToken(clientID)
+          .requestServerAuthCode(clientID)
           .requestScopes(new Scope("email"), _scopes)
           .build();
       }
@@ -169,7 +170,8 @@ public class RNGoogleSigninModule
             params.putString("name", acct.getDisplayName());
             params.putString("email", acct.getEmail());
             params.putString("photo", photoUrl != null ? photoUrl.toString() : null);
-            params.putString("accessToken", acct.getIdToken());
+            params.putString("idToken", acct.getIdToken());
+            params.putString("code", acct.getServerAuthCode());
             params.putArray("scopes", scopes);
 
             _context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)

--- a/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/co/apptailor/googlesignin/RNGoogleSigninModule.java
@@ -50,12 +50,23 @@ public class RNGoogleSigninModule
 
     @ReactMethod
     public void configure(final String clientID, final ReadableArray scopes) {
+      this._configure(clientID, null, scopes);
+    }
+
+    @ReactMethod
+    public void configureWithServerClientId(final String clientID, final String serverClientId, final ReadableArray scopes) {
+      this._configure(clientID, serverClientId, scopes);
+    }
+
+    public void _configure(final String clientID, final String serverClientId, final ReadableArray scopes) {
+        final String _clientID = (clientID != null ? clientID : serverClientId);
+
         _activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 _apiClient = new GoogleApiClient.Builder(_activity.getBaseContext())
 //                        .enableAutoManage(_activity, RNGoogleSigninModule.this)
-                        .addApi(Auth.GOOGLE_SIGN_IN_API, getSignInOptions(clientID, scopes))
+                        .addApi(Auth.GOOGLE_SIGN_IN_API, getSignInOptions(_clientID, scopes))
                         .build();
                 _apiClient.connect();
                 start();

--- a/ios-guide.md
+++ b/ios-guide.md
@@ -52,13 +52,20 @@ Inside AppDelegate.m
 ````
 
 From your JS files
-```
+```js
 var { NativeAppEventEmitter } = require('react-native');
 var GoogleSignin = require('react-native-google-signin');
 
 // configure API keys and access right
 GoogleSignin.configure(
   CLIENT_ID, // from .plist file
+  SCOPES // array of authorization names: eg ['https://www.googleapis.com/auth/calendar'] for requesting access to user calendar
+);
+
+// Or if you want to get serverAuthToken
+GoogleSignin.configureWithServerClientId(
+  CLIENT_ID, // from .plist file
+  SERVER_CLIENT_ID, // client ID from your backend server
   SCOPES // array of authorization names: eg ['https://www.googleapis.com/auth/calendar'] for requesting access to user calendar
 );
 

--- a/ios-guide.md
+++ b/ios-guide.md
@@ -38,7 +38,7 @@ Add the end of this step, your Xcode config should look like this:
 ### Usage
 
 Inside AppDelegate.m
-```
+```objc
 // add this line before @implementation AppDelegate
 #import "RNGoogleSignin.h"
 


### PR DESCRIPTION
`idToken` is different than `accessToken`. `idToken` is for verifing identity, while `accessToken` is needed to use Google API. `serverAuthCode` is code that you can use along with your secret to obtain `accessToken`.
You can't get `accessToken` for Android without this stage (even using Client ID of the type web), so I would return what is possible to get - `idToken` and `serverAuthCode` and not introducing confusiion by naming any of them `accessToken`.