### PR TITLE
Fix Reject Promise for currentUserAsync

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -74,9 +74,9 @@ class GoogleSignin {
         resolve(user);
       });
 
-      const errorCb = NativeAppEventEmitter.addListener('RNGoogleSignInError', () => {
+      const errorCb = NativeAppEventEmitter.addListener('RNGoogleSignInError', (err) => {
         this._removeListeners(sucessCb, errorCb);
-        resolve(null);
+        reject(err);
       });
 
       RNGoogleSignin.currentUserAsync();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-google-signin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Google Signin for your react native applications",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
Upon an error, the promise was incorrectly being resolved every time with a null value. I couldn't understand how that could be an intended feature, so assuming its a bug.